### PR TITLE
Add interface list keywords for a site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 /pkg/
 /spec/reports/
 /tmp/
+/.pryrc
+/Gemfile.lock
 
 # rspec failure tracking
 .rspec_status

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,27 @@ PATH
   remote: .
   specs:
     getstat (0.1.0)
+      sawyer (~> 0.8.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    coderay (1.1.2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
+    faraday (0.14.0)
+      multipart-post (>= 1.2, < 3)
+    hashdiff (0.3.7)
+    method_source (0.8.2)
+    multipart-post (2.0.0)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    public_suffix (3.0.1)
     rake (10.5.0)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
@@ -21,6 +37,15 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
+    safe_yaml (1.0.4)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
+    slop (3.6.0)
+    webmock (2.3.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -28,8 +53,10 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.16)
   getstat!
+  pry (~> 0.10.4)
   rake (~> 10.0)
   rspec (~> 3.0)
+  webmock (~> 2.0)
 
 BUNDLED WITH
    1.16.1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# Getstat
+# Getstat Client
+
+[![Build
+Status](https://travis-ci.org/abunashir/getstat.svg?branch=master)](https://travis-ci.org/abunashir/getstat)
 
 The Ruby Interface to the Getstat API.
 
@@ -16,13 +19,55 @@ And then execute:
 $ bundle install
 ```
 
+## Configure
+
+We need to setup Getstat API configuration before we can perform any request
+throughout this client
+
+First, [obtain an API key] for your account, and once you have it then you can
+configure the client by adding an initializer with the following code:
+
+```ruby
+Getstat.configure do |config|
+  config.api_host = "www.getstat.com"
+  config.api_key = "YourSecretAPIKey"
+end
+```
+
 ## Usage
+
+### List Keywords
+
+```ruby
+Getstat::Keyword.list(site_id: 1234, **other_params)
+```
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+We are following Sandi Metz's Rules for this gem, you can read the [description
+of the rules here] All new code should follow these rules. If you make changes in
+a pre-existing file that violates these rules you should fix the violations as
+part of your contribution.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+### Setup
+
+Clone the repository.
+
+```sh
+git clone https://github.com/abunashir/getstat
+```
+
+Setup your environment.
+
+```sh
+bin/setup
+```
+
+Run the test suite
+
+```sh
+bin/rspec
+```
 
 ## Contributing
 
@@ -31,3 +76,6 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/abunas
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+
+[obtain an API key]: https://help.getstat.com/knowledgebase/using-the-stat-api/
+[description of the rules here]: http://robots.thoughtbot.com/post/50655960596/sandi-metz-rules-for-developers

--- a/bin/console
+++ b/bin/console
@@ -2,13 +2,9 @@
 
 require "bundler/setup"
 require "getstat"
+require "pry"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
 
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
-
-require "irb"
-IRB.start(__FILE__)
+Pry.start

--- a/getstat.gemspec
+++ b/getstat.gemspec
@@ -30,7 +30,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "sawyer", "~> 0.8.1"
+
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "pry", "~> 0.10.4"
+  spec.add_development_dependency "webmock", "~> 2.0"
 end

--- a/lib/getstat.rb
+++ b/lib/getstat.rb
@@ -1,5 +1,9 @@
 require "getstat/version"
+require "getstat/request"
+require "getstat/keyword"
 
 module Getstat
-  # Your code goes here...
+  def self.root
+    File.dirname(__dir__)
+  end
 end

--- a/lib/getstat/config.rb
+++ b/lib/getstat/config.rb
@@ -1,0 +1,20 @@
+require "getstat/configuration"
+
+module Getstat
+  module Config
+    def configure
+      if block_given?
+        yield configuration
+      end
+    end
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
+  end
+
+  # This exposes the configuration methods in global scope, so
+  # we can directly use those like: `Getstat.configuration`.
+  #
+  extend Config
+end

--- a/lib/getstat/configuration.rb
+++ b/lib/getstat/configuration.rb
@@ -1,0 +1,14 @@
+module Getstat
+  class Configuration
+    attr_accessor :api_key, :api_host, :version
+
+    def initialize
+      @api_host ||= "www.getstat.com"
+      @version = "v2"
+    end
+
+    def base_path
+      ["api", version, api_key].join("/")
+    end
+  end
+end

--- a/lib/getstat/keyword.rb
+++ b/lib/getstat/keyword.rb
@@ -1,0 +1,15 @@
+module Getstat
+  class Keyword
+    # List keywords
+    #
+    # List the keywords for a specific site id
+    # @params site_id The site id as hash agrument
+    # @params params [Hash] Other params as a Hash
+    # @return [Sawyer::Resource]
+    #
+    def self.list(site_id:, params: {})
+      keywords = Request.get("keywords/list", query: params.merge(site_id: site_id))
+      keywords["Response"]
+    end
+  end
+end

--- a/lib/getstat/request.rb
+++ b/lib/getstat/request.rb
@@ -1,0 +1,76 @@
+require "sawyer"
+require "getstat/config"
+
+module Getstat
+  class Request
+    # Initialize a Request
+    #
+    # @param http_method [Symbol] HTTP verb as sysmbol
+    # @param endpoint [String] The relative API endpoint
+    # @param data [Hash] Attributes / Options as a Hash
+    #
+    def initialize(http_method, endpoint, **data)
+      @data = data
+      @endpoint = endpoint
+      @http_method = http_method
+    end
+
+    # Make a HTTP Request
+    #
+    # @param options [Hash] Additonal options hash
+    # @return [Sawyer::Resource]
+    #
+    def request(options = {})
+      options[:query] = { format: "json" }
+      options[:query].merge!(extract_config_option(:query) || {})
+
+      agent.call(http_method, api_endpoint, data, options).data
+    end
+
+    # Make a HTTP GET Request
+    #
+    # @param endpoint [String] The relative API endpoint
+    # @param options [Hash] The additional query params
+    # @return [Sawyer::Resource]
+    #
+    def self.get(endpoint, options = {})
+      new(:get, endpoint, options).request
+    end
+
+    private
+
+    attr_reader :client, :data, :http_method
+
+    def config
+      Getstat.configuration
+    end
+
+    def getstat_host
+      config.api_host
+    end
+
+    def extract_config_option(key)
+      if data.is_a?(Hash)
+        data.delete(key.to_sym)
+      end
+    end
+
+    def api_endpoint
+      URI::HTTPS.build(
+        host: getstat_host,
+        path: ["", config.base_path, @endpoint].join("/").squeeze("/"),
+      )
+    end
+
+    def sawyer_options
+      { links_parser: Sawyer::LinkParsers::Simple.new }
+    end
+
+    def agent
+      @agent ||= Sawyer::Agent.new(getstat_host, sawyer_options) do |http|
+        http.headers[:accept] = "application/json"
+        http.headers[:content_type] = "application/json"
+      end
+    end
+  end
+end

--- a/lib/getstat/rspec.rb
+++ b/lib/getstat/rspec.rb
@@ -1,0 +1,19 @@
+#RSpec Test Helpers
+#
+# Actual API requests are slow and expensive and we try not to make
+# actual request when possible. For most of our tests we mock those
+# API call which verifies the endpoint, http verb and headers and
+# based on those it responses with an identical fixture file
+#
+# The main purpose of this file is to allow the user to use our test
+# helpers by simplify adding this file to their application and then
+# use the available helper  method when necessary.
+#
+# We do not require this module with the gem by default, but you can
+# do so by adding `require "getstat/rspec"` on top of `spec_helper`
+#
+require File.join(Getstat.root, "spec/support/fake_getstat_api.rb")
+
+RSpec.configure do |config|
+  config.include Getstat::FakeGetstatApi
+end

--- a/spec/fixtures/keywords-list.json
+++ b/spec/fixtures/keywords-list.json
@@ -1,0 +1,53 @@
+{
+  "Response": {
+    "responsecode": "200",
+    "resultsreturned": "100",
+    "totalresults": "9540",
+    "nextpage": "/keywords/list?site_id=123&start=100&format=json",
+    "Result": [
+      {
+        "Id": "25440818",
+        "Keyword": "s-hertogenbosch",
+        "KeywordMarket": "IE-en",
+        "KeywordLocation": null,
+        "KeywordDevice": "desktop",
+        "KeywordTags": "201801, clp control",
+        "KeywordStats": {
+          "AdvertiserCompetition": "0.571429",
+          "GlobalSearchVolume": "590",
+          "RegionalSearchVolume": "10",
+          "LocalSearchTrendsByMonth": {
+            "Dec": "10",
+            "Nov": "0",
+            "Oct": "10",
+            "Sep": "0",
+            "Aug": "0",
+            "Jul": "0",
+            "Jun": "10",
+            "May": "10",
+            "Apr": "10",
+            "Mar": "10",
+            "Feb": "10",
+            "Jan": "10"
+          },
+          "CPC": "0.0"
+        },
+        "KeywordRanking": {
+          "date": "2018-01-30",
+          "Google": {
+            "Rank": "7",
+            "BaseRank": "4",
+            "Url": "www.trivago.ie/-s-hertogenbosch-4334/hotel"
+          },
+          "Bing": {
+            "Rank": "28",
+            "Url": "www.trivago.ie/-s-hertogenbosch-4334/hotel"
+          }
+        },
+        "CreatedAt": "2018-01-11",
+        "RequestUrl": "/rankings/list?keyword_id=2334444&format=json&from_date=2018-01-11&to_date="
+      }
+    ]
+  }
+}
+

--- a/spec/getstat/config_spec.rb
+++ b/spec/getstat/config_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+RSpec.describe  Getstat::Config do
+  describe ".configuration" do
+    it "retrives the current client configuration" do
+      api_key = "super-secret-api-key"
+      api_host = "trivago.getstat.com"
+
+      Getstat.configure do |getstat_config|
+        getstat_config.api_key = api_key
+        getstat_config.api_host = api_host
+      end
+
+      config = Getstat.configuration
+      expect(config.api_host).to eq(api_host)
+      expect(config.base_path).to eq("api/v2/#{api_key}")
+    end
+  end
+end

--- a/spec/getstat/keyword_spec.rb
+++ b/spec/getstat/keyword_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+RSpec.describe Getstat::Keyword do
+  describe ".list" do
+    it "retrieves the list of keywords" do
+      stub_keyword_list_api(123)
+      keywords = Getstat::Keyword.list(site_id: 123)
+
+      expect(keywords["Result"].count).to eq(1)
+      expect(keywords["Result"].first["Id"]).not_to be_nil
+      expect(keywords["Result"].first["KeywordMarket"]).to eq("IE-en")
+      expect(keywords["Result"].first["Keyword"]).to eq("s-hertogenbosch")
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,10 @@
+require "webmock/rspec"
 require "bundler/setup"
+
 require "getstat"
+require "getstat/rspec"
+
+Dir["./spec/support/**/*.rb"].sort.each { |file| require file }
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -10,5 +15,11 @@ RSpec.configure do |config|
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+  end
+
+  config.before :all do
+    Getstat.configure do |getstat_config|
+      getstat_config.api_key = "GETSTAT_API_KEY"
+    end
   end
 end

--- a/spec/support/fake_getstat_api.rb
+++ b/spec/support/fake_getstat_api.rb
@@ -1,0 +1,38 @@
+module Getstat
+  module FakeGetstatApi
+    def stub_keyword_list_api(site_id)
+      stub_api_response(
+        :get,
+        "keywords/list?format=json&site_id=#{site_id}",
+        filename: "keywords-list",
+      )
+    end
+
+    private
+
+    def stub_api_response(method, endpoint, filename:, status: 200, data: nil)
+      stub_http_request(method, getstat_endpoint(endpoint)).
+        to_return(response_with(filename: filename, status: status))
+    end
+
+    def response_with(filename:, status:)
+      {
+        status: status,
+        body: getstat_fixture(filename),
+        headers: { content_type: "application/json" },
+      }
+    end
+
+    def getstat_fixture(filename)
+      filename = [filename, "json"].join(".")
+      file_path = File.join(Getstat.root, "spec", "fixtures", filename)
+
+      File.read(File.expand_path(file_path, __FILE__))
+    end
+
+    def getstat_endpoint(endpoint)
+      config = Getstat.configuration
+      @host ||= "https://#{config.api_host}/#{config.base_path}/#{endpoint}"
+    end
+  end
+end


### PR DESCRIPTION
This commit adds the interface to list the keywords for a specific site id, and it also parses those response to `Sawyer::Resource`.

```ruby
Getstat::Keyword.list(site_id: 123, start: 100)
```