### PR TITLE
Remove params key for additional parameters

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    getstat (0.1.0)
+    getstat (0.1.1)
       sawyer (~> 0.8.1)
 
 GEM

--- a/lib/getstat/keyword.rb
+++ b/lib/getstat/keyword.rb
@@ -7,7 +7,7 @@ module Getstat
     # @params params [Hash] Other params as a Hash
     # @return [Sawyer::Resource]
     #
-    def self.list(site_id:, params: {})
+    def self.list(site_id:, **params)
       keywords = Request.get("keywords/list", query: params.merge(site_id: site_id))
       keywords["Response"]
     end

--- a/lib/getstat/version.rb
+++ b/lib/getstat/version.rb
@@ -1,3 +1,3 @@
 module Getstat
-  VERSION = "0.1.0".freeze
+  VERSION = "0.1.1".freeze
 end


### PR DESCRIPTION
Currently, the `Keyword.list` interface expects us to pass all of the parameters under `params` key, but technically based on the get stat api all additional parameters are pass as query, so it
might be easier to add support for keyword arguments so developer can pass any key they need.